### PR TITLE
Disable Create Account Button if input is not valid

### DIFF
--- a/frontend/my-app/src/Pages/CreateAccount.tsx
+++ b/frontend/my-app/src/Pages/CreateAccount.tsx
@@ -179,6 +179,8 @@ const CreateAccount: React.FC = () => {
             <Button
               onClick={handleCreate}
               fullWidth
+              disabled={(emailError || passwordError || addressError ||
+                        email.length === 0 || password.length === 0 || address.length === 0)}
               variant="contained"
               sx={{ mt: 3, mb: 2, bgcolor: 'secondary.main' }}
             >


### PR DESCRIPTION
In this PR I added a bit of logic to disable the create account button if the input is not valid. This is to prevent users from accidentally submitting bad information to the backend